### PR TITLE
[#103] fix(backend): suppress AuthlibDeprecationWarning from fastmcp jose dependency

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,16 @@
 import os
+import warnings
 from typing import Optional
 
 from pydantic_settings import BaseSettings
+
+# Suppress deprecation warnings from authlib
+try:
+    from authlib.deprecate import AuthlibDeprecationWarning
+
+    warnings.filterwarnings("ignore", category=AuthlibDeprecationWarning)
+except ImportError:
+    pass
 
 
 class Settings(BaseSettings):
@@ -76,9 +85,7 @@ class Settings(BaseSettings):
 
     # Weather MCP Server
     USE_ONLY_FREE_WEATHER_MCP_TOOLS: bool = True
-    WEATHER_MCP: str = os.getenv(
-        "WEATHER_MCP", "http://localhost:8200/mcp/"
-    )
+    WEATHER_MCP: str = os.getenv("WEATHER_MCP", "http://localhost:8200/mcp/")
 
     # Email settings (SMTP)
     SMTP_HOST: str = os.getenv("SMTP_HOST", "akvomail.org")

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -19,14 +19,14 @@ if [ "$ENVIRONMENT" = "development" ]; then
     default-libmysqlclient-dev \
     pkg-config \
     netcat-traditional
-    
+
     echo "Installing Python dependencies..."
     mkdir -p "$PIP_CACHE_DIR"
     pip install -q --upgrade pip
     pip install -q --cache-dir="$PIP_CACHE_DIR" -r requirements.txt || \
     (echo "Retrying in 5s..." && sleep 5 && pip install -q --cache-dir="$PIP_CACHE_DIR" -r requirements.txt) || \
     (echo "Retrying in 10s..." && sleep 10 && pip install -q --cache-dir="$PIP_CACHE_DIR" -r requirements.txt)
-    
+
     mkdir -p /app/uploads
 fi
 

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -9,8 +9,6 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
-const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
-];
+const eslintConfig = [...compat.extends("next/core-web-vitals")];
 
 export default eslintConfig;


### PR DESCRIPTION
## What
Suppresses the annoying `AuthlibDeprecationWarning` thrown by `fastmcp` importing `authlib.jose` at startup and cleans up frontend Next.js 14 ESLint configuration.

## Why
1. Clean up logs and console outputs during backend, worker, beat, and CLI start (such as running the `mcp_discovery_manager` tool).
2. Fix ESLint configurations in the frontend container to prevent errors on lint checks due to the `next/typescript` extension (unsupported in Next.js 14).

## How
1. **Backend warning filter**: Imported and registered an ignore warning filter targeting `AuthlibDeprecationWarning` in `backend/app/core/config.py` before other imports pull in `fastmcp` (e.g. CLI, Celery tasks, FastAPI router).
2. **Frontend lint fix**: Removed the `next/typescript` extension from flat config file `eslint.config.mjs` as flat configurations in Next.js 14 only require `next/core-web-vitals`.

## Verification & Testing
- Checked flake8 on changed python files: **All clean**
- Checked black on changed python files: **All clean**
- Ran backend test suite: **233/233 tests passed successfully**
- Ran frontend Next.js production build: **Compiled and optimized successfully**

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214921965194942